### PR TITLE
Fixed bug with -p in sqlclient

### DIFF
--- a/bin/qasino_sqlclient.py
+++ b/bin/qasino_sqlclient.py
@@ -272,7 +272,7 @@ if __name__ == "__main__":
         # switch to the right default port for zmq
         options.port = constants.ZMQ_RPC_PORT
     
-    print "Connecting to %s %s:%d." % ('https' if options.use_https else 'zmq', 
+    print "Connecting to %s %s:%s." % ('https' if options.use_https else 'zmq', 
                                        options.hostname, options.port)
 
 


### PR DESCRIPTION
The problem: error when running qasino_sqlclient using the -p flag (to specify that the qasino server is not running on the default port).  This is because flags are parsed as strings, but there's a print format line that attempts to read the -p flag value as an integer.

To reproduce:
    python qasino_sqlclient.py -H 1.2.3.4 -p 12345

Changing the print format to string solves the problem.