### PR TITLE
Dockerfile.client

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,10 @@
+FROM python:2.7-wheezy
+
+ADD ./ /opt/qasino
+COPY src/docker-entrypoint.sh /opt/qasino
+
+WORKDIR /opt/qasino/bin
+RUN pip install -r /opt/qasino/requirements.txt
+
+
+ENTRYPOINT ["/opt/qasino/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+VERSION := `head -1 debian/changelog | awk '{print $2}' | grep -o '\d\+.\d\+'`
+
+all: docker-client docker-server
+
+pkg:
+	dpkg-deb --build debian	
+
+docker-client:
+	docker build -t "qasino-client:${VERSION}" -f Dockerfile.client .
+	echo "Client container image created."
+
+docker-server:
+	docker build -t "qasino-server:${VERSION}" .
+	echo "Server container image created"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := `head -1 debian/changelog | awk '{print $2}' | grep -o '\d\+.\d\+'`
+VERSION := `head -1 debian/changelog | awk '{print $2}' | grep -o -e '\([0-9\.]\+\)' | tr -d '()'`
 
 all: docker-client docker-server
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Python libraries installed:
 - python-txzmq
 - python-jinja2
 
+For this you can use
+
+    pip install -r requirements.txt
+
 The server and the client can be run right from the main directory.
 They will find the libraries they need in the lib directory. To run the server:
 
@@ -70,6 +74,10 @@ Connect with the SQL client:
 To run the CSV publisher:
 
     python bin/qasino_csvpublisher.py --identity 1.2.3.4 --index-file index.csv
+    
+###Building
+
+You can run *make* against the root directory of this project to generate docker images for the qasino client and server. You can also run *make pkg* to generate a debian package.
 
 ###Docker
 
@@ -87,6 +95,14 @@ to send requests to the qasino server.  For example:
 
 You can find the ports that Docker assigned to your qasino container using
 `docker ps`.
+
+It is also possible to build a Docker image for the client.
+
+    docker build -t "my-qasino-client" -f Dockerfile.client /path/to/qasino
+    
+This will create the qasino client Docker image. The default run command for this image expects an environment variable of QASINO_HOST and will run qasino_sqlclient.py by default
+
+    docker run -it -e QASINO_HOST=my-qasino-host my-qasino-client
 
 ###Pip (client only)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+twisted
+zmq
+httplib2
+apsw
+requests
+jinja2
+txzmq

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ -z "$1" ]; then
 
   if [ -z $QASINO_HOST ]; then
-    echo "Please spcify a QASINO_HOST."
+    echo "Please specify a QASINO_HOST."
     exit 1
   fi
 

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+
+  if [ -z $QASINO_HOST ]; then
+    echo "Please spcify a QASINO_HOST."
+    exit 1
+  fi
+
+  exec python qasino_sqlclient.py -H $QASINO_HOST
+fi
+
+exec "$@"


### PR DESCRIPTION
Added docker file to build the client code. Also added requirements.txt to track python libraries which need to be installed. This can then be run using pip install -r requirements.txt. Added a Makefile for build process

Using the docker build -f flag which now supports multiple Dockerfiles in the same repository for cases like this.

